### PR TITLE
orderhelp typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,19 @@
   "version": "1.1.3",
   "homepage": "https://github.com/slimandslam/schwab-client-js#readme",
   "main": "./dist/schwab-client-js.js",
+  "types": "./dist/schwab-client-js.d.ts",
   "bugs": {
     "url": "https://github.com/slimandslam/schwab-client-js/issues"
   },
   "support": {
     "url": "https://discord.gg/Q9z8EnB8xD"
+  },
+  "typesVersions": {
+    "*": {
+      "orderhelp": [
+        "dist/orderhelp.d.ts"
+      ]
+    }
   },
   "exports": {
     ".": "./dist/schwab-client-js.js",


### PR DESCRIPTION
Update `package.json` to include `typesVersions` object with reference to orderhelp types.